### PR TITLE
Fix little typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Using a new amazing feature - Swift Package Manager prebuild plugin, you can gen
 
 ```
 plugins: [
-    .plugin(name: "packageBuildInfoPlugin", package: "PackageBuildInfo")
+    .plugin(name: "PackageBuildInfoPlugin", package: "PackageBuildInfo")
 ]
 ```
 


### PR DESCRIPTION
Page name have to be uppercased.

```
plugins: [
    .plugin(name: "PackageBuildInfoPlugin", package: "PackageBuildInfo")
]
```
works, packageBuildInfoPlugin has a build error.

