### PR TITLE
made PackageBuild Sendable

### DIFF
--- a/Binaries/PackageBuildInfo.artifactbundle/universal/packageBuildInfo.sh
+++ b/Binaries/PackageBuildInfo.artifactbundle/universal/packageBuildInfo.sh
@@ -98,7 +98,7 @@ echo "/////
 //
 import Foundation
 
-public struct PackageBuild {
+public struct PackageBuild: Sendable {
     public let isDirty: Bool       // Dirty build - git directory is't clean.
     public let timeStamp: Date     // Time of last commit
     public let timeZone: TimeZone  // Time Zone


### PR DESCRIPTION
Xcode was complaining that PackageBuild is not sendable in a new project. I made it sendable, now the project builds without issues.